### PR TITLE
fix: 소셜 로그인을 signInWithPopup → signInWithRedirect로 전환

### DIFF
--- a/todays-vibe/src/app/(auth)/login/page.tsx
+++ b/todays-vibe/src/app/(auth)/login/page.tsx
@@ -1,12 +1,13 @@
 "use client";
 
-import { useState, FormEvent, Suspense } from "react";
+import { useState, useEffect, FormEvent, Suspense } from "react";
 import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
 import {
   signInWithEmail,
   signInWithGoogle,
   signInWithGithub,
+  getAuthRedirectResult,
   createSession,
 } from "@/lib/firebase/auth";
 
@@ -19,6 +20,20 @@ function LoginForm() {
   const [password, setPassword] = useState("");
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    getAuthRedirectResult()
+      .then(async (result) => {
+        if (!result) return;
+        setLoading(true);
+        const isAdmin = await createSession(result.user);
+        router.push(getDestination(isAdmin));
+      })
+      .catch((err) => {
+        console.error("[Redirect] 로그인 에러:", err);
+        setError("소셜 로그인에 실패했습니다.");
+      });
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   function getDestination(isAdmin: boolean) {
     return isAdmin ? "/admin" : redirectTo;
@@ -39,28 +54,20 @@ function LoginForm() {
     }
   }
 
-  async function handleGoogle() {
+  function handleGoogle() {
     setError("");
-    try {
-      const result = await signInWithGoogle();
-      const isAdmin = await createSession(result.user);
-      router.push(getDestination(isAdmin));
-    } catch (err) {
+    signInWithGoogle().catch((err) => {
       console.error("[Google] 로그인 에러:", err);
       setError("구글 로그인에 실패했습니다.");
-    }
+    });
   }
 
-  async function handleGithub() {
+  function handleGithub() {
     setError("");
-    try {
-      const result = await signInWithGithub();
-      const isAdmin = await createSession(result.user);
-      router.push(getDestination(isAdmin));
-    } catch (err) {
+    signInWithGithub().catch((err) => {
       console.error("[GitHub] 로그인 에러:", err);
       setError("깃허브 로그인에 실패했습니다.");
-    }
+    });
   }
 
   return (

--- a/todays-vibe/src/lib/firebase/auth.ts
+++ b/todays-vibe/src/lib/firebase/auth.ts
@@ -4,7 +4,8 @@ import {
   getAuth,
   signInWithEmailAndPassword,
   createUserWithEmailAndPassword,
-  signInWithPopup,
+  signInWithRedirect,
+  getRedirectResult,
   signOut as firebaseSignOut,
   GoogleAuthProvider,
   GithubAuthProvider,
@@ -36,11 +37,15 @@ export async function signUpWithEmail(
 }
 
 export async function signInWithGoogle() {
-  return signInWithPopup(auth(), googleProvider);
+  return signInWithRedirect(auth(), googleProvider);
 }
 
 export async function signInWithGithub() {
-  return signInWithPopup(auth(), githubProvider);
+  return signInWithRedirect(auth(), githubProvider);
+}
+
+export async function getAuthRedirectResult() {
+  return getRedirectResult(auth());
 }
 
 export async function signInWithToken(token: string) {


### PR DESCRIPTION
팝업 방식은 async 함수 컨텍스트에서 브라우저가 사용자 제스처를
인식하지 못해 운영 환경에서 auth/popup-blocked 발생.
리다이렉트 방식으로 전환하여 팝업 차단 이슈 완전 해소.