### PR TITLE
fix: Vercel 운영 환경에서 소셜 로그인 팝업 차단 문제 해결

### DIFF
--- a/todays-vibe/vercel.json
+++ b/todays-vibe/vercel.json
@@ -4,5 +4,16 @@
       "path": "/api/cron/fortune",
       "schedule": "30 14 * * *"
     }
+  ],
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": [
+        {
+          "key": "Cross-Origin-Opener-Policy",
+          "value": "same-origin-allow-popups"
+        }
+      ]
+    }
   ]
 }


### PR DESCRIPTION
Cross-Origin-Opener-Policy 헤더를 vercel.json에 추가하여
Firebase signInWithPopup의 팝업↔부모창 통신 허용.