### PR TITLE
debug: Google OAuth 콜백 상세 에러 로깅 추가 + 로그인 로고 교체

### DIFF
--- a/todays-vibe/src/app/(auth)/login/page.tsx
+++ b/todays-vibe/src/app/(auth)/login/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState, FormEvent, Suspense } from "react";
 import Link from "next/link";
+import Image from "next/image";
 import { useRouter, useSearchParams } from "next/navigation";
 import { signInWithEmail, createSession } from "@/lib/firebase/auth";
 
@@ -46,11 +47,8 @@ function LoginForm() {
     <div className="w-full max-w-sm">
       {/* Logo */}
       <div className="text-center mb-8">
-        <Link href="/" className="inline-flex flex-col items-center gap-2">
-          <span className="text-5xl">🔮</span>
-          <span className="text-white font-bold text-2xl tracking-tight">
-            오늘운
-          </span>
+        <Link href="/" className="inline-block">
+          <Image src="/brand/logo.svg" alt="오늘운" width={200} height={67} priority />
         </Link>
         <p className="text-white/50 text-sm mt-2">AI가 풀어주는 나만의 운세</p>
       </div>

--- a/todays-vibe/src/app/api/auth/google/callback/route.ts
+++ b/todays-vibe/src/app/api/auth/google/callback/route.ts
@@ -26,6 +26,7 @@ export async function GET(req: NextRequest) {
 
   try {
     const redirectUri = `${process.env.NEXT_PUBLIC_BASE_URL}/api/auth/google/callback`;
+    console.log("[Google OAuth] redirect_uri:", redirectUri);
 
     const tokenRes = await fetch("https://oauth2.googleapis.com/token", {
       method: "POST",
@@ -39,13 +40,13 @@ export async function GET(req: NextRequest) {
       }),
     });
     const tokenData: GoogleTokenResponse = await tokenRes.json();
-    if (tokenData.error) throw new Error(tokenData.error);
+    if (tokenData.error) throw new Error(`token_error: ${tokenData.error}`);
 
     const userRes = await fetch("https://www.googleapis.com/oauth2/v2/userinfo", {
       headers: { Authorization: `Bearer ${tokenData.access_token}` },
     });
     const userData: GoogleUserResponse = await userRes.json();
-    if (userData.error) throw new Error(userData.error.message);
+    if (userData.error) throw new Error(`userinfo_error: ${userData.error.message}`);
 
     const uid = `google:${userData.id}`;
     await upsertOAuthUser(uid, {
@@ -66,7 +67,7 @@ export async function GET(req: NextRequest) {
     res.cookies.delete("google_oauth_state");
     return res;
   } catch (err) {
-    console.error("[Google OAuth callback]", err);
-    return NextResponse.redirect(new URL("/login?error=google_failed", req.url));
+    console.error("[Google OAuth callback] 상세 에러:", String(err));
+    return NextResponse.redirect(new URL(`/login?error=google_failed&detail=${encodeURIComponent(String(err))}`, req.url));
   }
 }


### PR DESCRIPTION
- Google OAuth 콜백에 단계별 에러 메시지 추가 (token_error / userinfo_error)
- 실패 시 URL에 detail 파라미터로 원인 노출
- 로그인 페이지 브랜드 로고 이모지→logo.svg 교체 (width 200)