### PR TITLE
fix: Google OAuth upsertOAuthUser 에러 처리 개선

### DIFF
--- a/todays-vibe/src/lib/firebase/admin.ts
+++ b/todays-vibe/src/lib/firebase/admin.ts
@@ -46,7 +46,16 @@ export async function upsertOAuthUser(
   const auth = getAdminAuth();
   try {
     await auth.updateUser(uid, profile);
-  } catch {
-    await auth.createUser({ uid, ...profile });
+  } catch (err: unknown) {
+    const code = (err as { code?: string })?.code;
+    if (code === "auth/user-not-found") {
+      await auth.createUser({ uid, ...profile });
+    } else if (code === "auth/email-already-exists") {
+      // 이메일 충돌 시 이메일 제외하고 프로필만 업데이트
+      const { email: _email, ...profileWithoutEmail } = profile;
+      await auth.updateUser(uid, profileWithoutEmail);
+    } else {
+      throw err;
+    }
   }
 }


### PR DESCRIPTION
updateUser 실패 시 무조건 createUser를 호출하던 버그 수정.
- auth/user-not-found일 때만 createUser 호출
- auth/email-already-exists는 이메일 제외하고 프로필만 업데이트
- 그 외 에러는 그대로 throw하여 원인 파악 가능